### PR TITLE
removed future_rev_count counter which is undefined and unused

### DIFF
--- a/mw/lib/persistence/api.py
+++ b/mw/lib/persistence/api.py
@@ -77,7 +77,6 @@ def track(session, rev_id, page_id=None, revert_radius=reverts.defaults.RADIUS,
     future_revs = list(future_revs)
     for rev in future_revs:
         state.process(rev.get('*', ""), rev, rev.get('sha1'))
-        future_rev_count += 1
     
     
     return current_rev, tokens_added, future_revs


### PR DESCRIPTION
The example file in `example/lib.persistence.api.py` does not run because the
`mw/lib/persistence/api.py` file includes a line incrementing the variable
future_rev_count which is undefined. Because the variable is not referred to
elsewhere, it seems safe to remove.