### PR TITLE
Import DummyChecksum before using it and fix an API call

### DIFF
--- a/mw/lib/persistence/api.py
+++ b/mw/lib/persistence/api.py
@@ -26,6 +26,8 @@ def track(session, rev_id, page_id=None, revert_radius=reverts.defaults.RADIUS,
     rev_id = int(rev_id)
     page_id = none_or(page_id, int)
     revert_radius = int(revert_radius)
+    if revert_radius < 1:
+        raise TypeError("invalid radius.  Expected a positive integer.")
     properties = set(properties) if properties is not None else set()
 
 
@@ -38,7 +40,7 @@ def track(session, rev_id, page_id=None, revert_radius=reverts.defaults.RADIUS,
     current_and_past_revs = list(session.revisions.query(
         pageids={page_id},
         limit=revert_radius + 1,
-        start_id=rev_id + 1,  # Ensures that we capture the current revision
+        start_id=rev_id,
         direction="older",
         properties={'ids', 'timestamp', 'content', 'sha1'} | properties
     ))
@@ -58,7 +60,7 @@ def track(session, rev_id, page_id=None, revert_radius=reverts.defaults.RADIUS,
     future_revs = session.revisions.query(
         pageids={page_id},
         limit=future_revisions,
-        start_id=rev_id+1,
+        start_id=rev_id + 1, # Ensures that we skip the current revision
         direction="newer",
         properties={'ids', 'timestamp', 'content', 'sha1'} | properties
     )

--- a/mw/lib/reverts/api.py
+++ b/mw/lib/reverts/api.py
@@ -3,6 +3,7 @@ from itertools import chain
 from . import defaults
 from ...types import Timestamp
 from ...util import none_or
+from .dummy_checksum import DummyChecksum
 from .functions import detect
 
 

--- a/mw/lib/reverts/database.py
+++ b/mw/lib/reverts/database.py
@@ -30,7 +30,7 @@ def check_row(db, rev_row, **kwargs):
         radius : int
             a positive integer indicating the the maximum number of revisions that can be reverted
         check_archive : bool
-            should the archive table be check for reverting revisions?
+            should the archive table be checked for reverting revisions?
         before : `Timestamp`
             if set, limits the search for *reverting* revisions to those which were saved before this timestamp
     """


### PR DESCRIPTION
Also, use the correct start_id in the API calls. Previously, an edit such as
https://en.wikibooks.org/w/index.php?diff=2607402
whose rev_id is equals to the rev_id of the previous revision of the page, plus one,
would get included in both `current_and_past_revs` and `future_revs` when scoring the
previous revision ([2607401](https://en.wikibooks.org/w/index.php?diff=2607401)).
    
Follows up cdec8b01a3b0b556d43f4f8e09bd4b259ce1dcb9 and 63aab1f70ba20f29a89e48bc345dd89471a7a9db.