### PR TITLE
Remove revisions from Page's __slots__

### DIFF
--- a/mw/xml_dump/iteration/page.py
+++ b/mw/xml_dump/iteration/page.py
@@ -27,7 +27,7 @@ class Page(serializable.Type):
         'restrictions',
     )
 
-    def __init__(self, id, title, namespace, redirect, restrictions, revisions):
+    def __init__(self, id, title, namespace, redirect, restrictions, revisions=[]):
         self.id = none_or(id, int)
         """
         Page ID : `int`

--- a/mw/xml_dump/iteration/page.py
+++ b/mw/xml_dump/iteration/page.py
@@ -25,7 +25,6 @@ class Page(serializable.Type):
         'namespace',
         'redirect',
         'restrictions',
-        'revisions'
     )
 
     def __init__(self, id, title, namespace, redirect, restrictions, revisions):

--- a/mw/xml_dump/iteration/tests/test_iterator.py
+++ b/mw/xml_dump/iteration/tests/test_iterator.py
@@ -6,6 +6,8 @@ from ....types import Timestamp
 from ..iterator import Iterator
 from ..comment import Comment
 from ..text import Text
+from ..revision import Revision
+from ..page import Page
 
 
 SAMPLE_XML = """
@@ -119,6 +121,7 @@ def test_complete():
     eq_(revision.beginningofpage, False)
 
     page = next(dump)
+    assert_is_instance(page, Page)
     eq_(page.title, "Bar")
     eq_(page.namespace, 1)
     eq_(page.id, 2)
@@ -126,6 +129,7 @@ def test_complete():
     eq_(page.restrictions, ["edit=sysop:move=sysop"])
 
     revision = next(page)
+    assert_is_instance(revision, Revision)
     eq_(revision.id, 3)
     eq_(revision.timestamp, Timestamp("2004-08-11T09:04:08Z"))
     eq_(revision.contributor.id, None)
@@ -136,8 +140,10 @@ def test_complete():
     eq_(revision.comment, None)
     eq_(revision.model, "wikitext")
     eq_(revision.format, "text/x-wiki")
+    assert_is_instance(str(page), str)
 
     revision = next(page)
+    assert_is_instance(revision, Revision)
     eq_(revision.id, 4)
     eq_(revision.timestamp, Timestamp("2004-08-12T09:04:08Z"))
     eq_(revision.contributor, None)
@@ -147,6 +153,7 @@ def test_complete():
     eq_(revision.comment, None)
     eq_(revision.model, "wikitext")
     eq_(revision.format, "text/x-wiki")
+    assert_is_instance(str(revision), str)
 
 
 def test_skipping():


### PR DESCRIPTION
Fixes a bug because Revisions are called using the generator and not as an attribute. The presence
of this in the __slots__ introduces some issues (e.g., printing a Page fails) because the object serialization code relies attributes listed in __slots__ actually existing.

As discussed on IRC, I've added tests and set a default value.