### PR TITLE
 add function to Revision to generate 'sha1' if it does not exist

### DIFF
--- a/mw/xml_dump/iteration/revision.py
+++ b/mw/xml_dump/iteration/revision.py
@@ -4,14 +4,14 @@ from .comment import Comment
 from .contributor import Contributor
 from .text import Text
 from .util import consume_tags
-
+from hashlib import sha1
 
 class Revision(serializable.Type):
     """
     Revision meta data.
     """
     __slots__ = ('id', 'timestamp', 'contributor', 'minor', 'comment', 'text',
-                 'bytes', 'sha1', 'parent_id', 'model', 'format',
+                 'bytes', 'parent_id', 'model', 'format',
                  'beginningofpage')
 
     TAG_MAP = {
@@ -66,7 +66,7 @@ class Revision(serializable.Type):
         Number of bytes of content : `str`
         """
 
-        self.sha1 = none_or(sha1, str)
+        self._sha1 = none_or(sha1, str)
         """
         sha1 hash of the content : `str`
         """
@@ -114,3 +114,16 @@ class Revision(serializable.Type):
                     # For Wikihadoop.
                     # Probably never used by anything, ever.
         )
+
+    @property
+    def sha1(self):
+        if not self._sha1:
+            if not self.text.deleted:
+                self._sha1 = sha1(bytes(self.text, "utf8")).hexdigest()
+
+        return self._sha1
+
+    @sha1.setter
+    def sha1(self, sha1):
+        self._sha1 = sha1
+

--- a/mw/xml_dump/iteration/tests/test_iterator.py
+++ b/mw/xml_dump/iteration/tests/test_iterator.py
@@ -255,3 +255,15 @@ def test_from_page_xml():
     eq_(revision.comment, "Comment 2")
     eq_(revision.model, "wikitext")
     eq_(revision.format, "text/x-wiki")
+
+def test_sha1_generate():
+    f = io.StringIO(SAMPLE_XML)
+    f = io.StringIO("".join([l for l in f if not l.startswith('      <sha1')]))
+
+    dump = Iterator.from_file(f)
+    page = next(dump)
+    revision = next(page)
+
+    eq_(revision.sha1, "ef2f21de058dd8dc37811ad4efcb27c14fa0bfc2")
+    revision = next(page)
+    eq_(revision.sha1, "4d5c0a395cf23c571c07393eb28d464d778da860")


### PR DESCRIPTION
In Wikia XML dumps and probably in other dumps, <sha1></sha1> tags in revisions
are missing.

This patch coverts the 'sha1' attribute into a property that will take or set a
SHA1 checksum (e.g., if it's defined in the dump) in which case the library
behavior should be unchanged.

If, however, the SHA1 is not defined in the dump, this patch will lazily
compute the SHA1 checksum the first time the propery is accessed.

This patches uses hashlib to generate hexadecimal hash digests and does not
generate the base36 SHA1 sums that Mediawiki uses.