### PR TITLE
Add method to iterate over passed XML

### DIFF
--- a/mw/xml_dump/iteration/iterator.py
+++ b/mw/xml_dump/iteration/iterator.py
@@ -187,6 +187,13 @@ class Iterator(serializable.Type):
         return cls.from_element(element)
     
     @classmethod
+    def from_ref(cls, ref):
+        f = io.StringIO(ref)
+        element = ElementIterator.from_file(f)
+        assert element.tag == "mediawiki"
+        return cls.from_element(element)
+    
+    @classmethod
     def from_page_xml(cls, page_xml):
         header = """
         <mediawiki xmlns="http://www.mediawiki.org/xml/export-0.5/"

--- a/mw/xml_dump/iteration/iterator.py
+++ b/mw/xml_dump/iteration/iterator.py
@@ -187,8 +187,8 @@ class Iterator(serializable.Type):
         return cls.from_element(element)
     
     @classmethod
-    def from_ref(cls, ref):
-        f = io.StringIO(ref)
+    def from_string(cls, string):
+        f = io.StringIO(string)
         element = ElementIterator.from_file(f)
         assert element.tag == "mediawiki"
         return cls.from_element(element)


### PR DESCRIPTION
This is purely sugar, but it stops me from having to create a temp file or invoke io.StringIO myself. We already import io, so I don't think it adds any real overhead.

Just borrows the pattern from the iterator test because I know next to nothing about Python.