### PR TITLE
Making query compatible with MW 1.26+

### DIFF
--- a/mw/api/collections/revisions.py
+++ b/mw/api/collections/revisions.py
@@ -153,7 +153,8 @@ class Revisions(Collection):
         
         params = {
             'action': "query",
-            'prop': "revisions"
+            'prop': "revisions",
+            'rawcontinue': ''
         }
         
         params['revids'] = self._items(revids, type=int)
@@ -179,7 +180,7 @@ class Revisions(Collection):
         params['rvparse'] = none_or(parse, bool)
         params['rvsection'] = none_or(section, int)
         params['rvtoken'] = none_or(token, str)
-        params['rvcontinue'] = none_or(rvcontinue, int)
+        params['rvcontinue'] = none_or(rvcontinue, str)
         params['rvdiffto'] = self._check_diffto(diffto)
         params['rvdifftotext'] = none_or(difftotext, str)
         params['rvcontentformat'] = none_or(contentformat, str)


### PR DESCRIPTION
According to https://www.mediawiki.org/wiki/API:Query#Backwards_compatibility_of_continue, in new versions of Mediawiki (including the version running currently on WP), the 'query-continue' parameter has been deprecated in favor of a simpler 'continue'. However, the old 'query-continue' can still be retrieved if the query parameter includes a 'rawcontinue' flag, which I added.