### PR TITLE
switch namespace name to use none_or()

### DIFF
--- a/mw/types/namespace.py
+++ b/mw/types/namespace.py
@@ -17,7 +17,7 @@ class Namespace(serializable.Type):
         Namespace ID : `int`
         """
 
-        self.name = str(name)
+        self.name = none_or(name, str)
         """
         Namespace name : `str`
         """


### PR DESCRIPTION
Namespace.name was being cast to a string which led to problems for namespace 0
(simply missing from XML dumps for most wikis) which was being set to the
string "None" instead of None.  Switching from `str(name)` to `none_or(name,
str)` fixes the issue.

This is important on wikis that do not include namespace data for each <page>
and where namespace issue must be inferred from the <title> in each page.
Looking titles that start with "None:" is a dead end.